### PR TITLE
Remove 'ignore: brands' for HACS validation

### DIFF
--- a/.github/workflows/hacs.yaml
+++ b/.github/workflows/hacs.yaml
@@ -15,4 +15,4 @@ jobs:
         uses: "hacs/action@main"
         with:
           category: integration
-          ignore: brands
+


### PR DESCRIPTION
Merge this PR **ONLY AFTER** your brand icons have been merged into the official Home Assistant brands repository. Once merged, wait for the HACS Action to pass on your main branch, and update your hacs/default PR with the new successful run URL.